### PR TITLE
Health checks

### DIFF
--- a/Habit.API/Habit.API.csproj
+++ b/Habit.API/Habit.API.csproj
@@ -8,6 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="5.0.1" />
         <PackageReference Include="FluentValidation" Version="10.3.0" />
         <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.0" />
         <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />

--- a/Habit.API/Startup.cs
+++ b/Habit.API/Startup.cs
@@ -37,6 +37,10 @@ namespace Habit.API
             services.AddFluentValidation();
             services.AddSignalR();
             
+            // health check
+            services.AddHealthChecks()
+                .AddMongoDb(_configuration.GetConnectionString("dabit-mongo-db"));
+            
             // cors
             services.AddCors(options =>
             {
@@ -82,6 +86,7 @@ namespace Habit.API
             {
                 endpoints.MapControllers();
                 endpoints.MapHub<HabitsHub>("/realtime");
+                endpoints.MapHealthChecks("/health");
             });
         }
     }

--- a/Habit.Infrastructure/DependenciesInjection.cs
+++ b/Habit.Infrastructure/DependenciesInjection.cs
@@ -5,7 +5,6 @@ using Domain.SeedWork;
 using Infrastructure.Events;
 using Infrastructure.Projections;
 using Infrastructure.Repositories;
-using Infrastructure.Subscriptions;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Infrastructure
@@ -15,7 +14,6 @@ namespace Infrastructure
         public static void AddInfrastructureDependenciesInjection(this IServiceCollection services) {
             // repositories
             services.AddScoped<IEventStoreRepository<Habit>, EventStoreRepository<Habit>>();
-            services.AddCheckpointRepository("subscription-checkpoint");
             services.AddMongoRepository<HabitProjection>(
                 "habits",
                 async collection => { await collection.AddGuidIndex(habit => habit.UserId); }

--- a/Habit.Worker/Habit.Worker.csproj
+++ b/Habit.Worker/Habit.Worker.csproj
@@ -4,10 +4,13 @@
         <TargetFramework>net5.0</TargetFramework>
         <UserSecretsId>dotnet-Habit.Worker-6ADC119B-3598-4A19-B4CA-AD1A0BE28923</UserSecretsId>
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+        <Nullable>enable</Nullable>
     </PropertyGroup>
 
     <ItemGroup>
+        <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="5.0.1" />
         <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks" Version="5.0.11" />
         <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     </ItemGroup>
 

--- a/Habit.Worker/Health/HealthCheckPublisher.cs
+++ b/Habit.Worker/Health/HealthCheckPublisher.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Habit.Worker.Health
+{
+    public class HealthCheckPublisher : IHealthCheckPublisher
+    {
+        private readonly string _filename;
+        private HealthStatus _prevStatus = HealthStatus.Unhealthy;
+
+        public HealthCheckPublisher(IConfiguration configuration) {
+            _filename = configuration.GetValue("HealthChecks:FilePath", "/tmp/healthy");
+        }
+
+        public Task PublishAsync(HealthReport report, CancellationToken cancellationToken) {
+            var fileExists = _prevStatus == HealthStatus.Healthy;
+
+            if (report.Status == HealthStatus.Healthy)
+            {
+                using var _ = File.Create(_filename);
+            }
+            else if (fileExists)
+            {
+                File.Delete(_filename);
+            }
+
+            _prevStatus = report.Status;
+
+            return Task.CompletedTask;
+        }
+    }
+
+    public static class HealthCheckPublisherConfig
+    {
+        public static void ConfigureHealthCheckPublisher(this IServiceCollection service) {
+            service.AddSingleton<IHealthCheckPublisher, HealthCheckPublisher>();
+            service.Configure<HealthCheckPublisherOptions>(options =>
+            {
+                options.Delay = TimeSpan.FromSeconds(5);
+                options.Period = TimeSpan.FromSeconds(20);
+            });
+        }
+    }
+}

--- a/Habit.Worker/Health/SubscriptionHealthCheck.cs
+++ b/Habit.Worker/Health/SubscriptionHealthCheck.cs
@@ -1,0 +1,30 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Habit.Worker.Health
+{
+    public class SubscriptionHealthCheck : IHealthCheck
+    {
+        private readonly SubscriptionState _subscriptionState;
+
+        public SubscriptionHealthCheck(SubscriptionState subscriptionState) {
+            _subscriptionState = subscriptionState;
+        }
+        
+        public Task<HealthCheckResult> CheckHealthAsync(
+            HealthCheckContext context,
+            CancellationToken cancellationToken = new()
+        ) {
+            return Task.FromResult(new HealthCheckResult(_subscriptionState.State));
+        }
+    }
+
+    public static class SubscriptionHealthCheckConfig
+    {
+        public static void AddSubscriptionCheck(this IHealthChecksBuilder builder) {
+            builder.AddCheck<SubscriptionHealthCheck>("subscription");
+        }
+    }
+}

--- a/Habit.Worker/Health/SubscriptionState.cs
+++ b/Habit.Worker/Health/SubscriptionState.cs
@@ -1,0 +1,9 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+
+namespace Habit.Worker.Health
+{
+    public class SubscriptionState
+    {
+        public HealthStatus State { get; set; }
+    }
+}

--- a/Habit.Worker/README.md
+++ b/Habit.Worker/README.md
@@ -1,0 +1,25 @@
+# Habit.Worker
+
+A background worker that subscribes to the event store and write the projection on mongo.
+
+## Features
+
+ - 📑 Projections
+ - 🔄 Resubscribe automatically
+ - 💖 Health checks
+
+## Configuration
+
+| key                                    | default value |
+|----------------------------------------|---------------|
+| HealthChecks:FilePath                  | /tmp/healthy  |
+| ConnectionStrings:dabit-event-store-db | -             |
+| ConnectionStrings:dabit-mongo-db       | -             |
+
+## Health Checks
+
+Health checks are performed through file presence instead of an http endpoint.
+If the file exist then the service is healthy, if it doesn't then it's unhealthy.
+
+Both the event store and mongo db connection are monitored.
+The default path is `/tmp/healthy`.

--- a/Habit.Worker/Subscriptions/ISubscriptionCheckpointRepository.cs
+++ b/Habit.Worker/Subscriptions/ISubscriptionCheckpointRepository.cs
@@ -2,7 +2,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using EventStore.Client;
 
-namespace Infrastructure.Subscriptions
+namespace Habit.Worker.Subscriptions
 {
     public interface ISubscriptionCheckpointRepository
     {

--- a/Habit.Worker/Subscriptions/SubscriptionCheckpoint.cs
+++ b/Habit.Worker/Subscriptions/SubscriptionCheckpoint.cs
@@ -1,7 +1,7 @@
 using System;
 using Domain.SeedWork;
 
-namespace Infrastructure.Subscriptions
+namespace Habit.Worker.Subscriptions
 {
     public record SubscriptionCheckpoint(Guid Id, ulong Position) : IIdentifiable;
 }

--- a/Habit.Worker/Subscriptions/SubscriptionCheckpointRepository.cs
+++ b/Habit.Worker/Subscriptions/SubscriptionCheckpointRepository.cs
@@ -1,13 +1,12 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Domain.SeedWork;
 using EventStore.Client;
 using Infrastructure.Repositories;
 using Microsoft.Extensions.DependencyInjection;
 using MongoDB.Driver;
 
-namespace Infrastructure.Subscriptions
+namespace Habit.Worker.Subscriptions
 {
     public class SubscriptionCheckpointRepository : MongoRepository<SubscriptionCheckpoint>,
         ISubscriptionCheckpointRepository

--- a/Identity.API/Identity.API.csproj
+++ b/Identity.API/Identity.API.csproj
@@ -8,17 +8,18 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="5.0.9"/>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.9"/>
-        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.9"/>
-        <PackageReference Include="MongoDB.Driver" Version="2.13.1"/>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3"/>
-        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.2.1"/>
-        <PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="6.2.1"/>
+        <PackageReference Include="AspNetCore.HealthChecks.MongoDb" Version="5.0.1" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="5.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="5.0.9" />
+        <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="5.0.9" />
+        <PackageReference Include="MongoDB.Driver" Version="2.13.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.2.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore.ReDoc" Version="6.2.1" />
     </ItemGroup>
 
     <ItemGroup>
-        <ProjectReference Include="..\Identity.JWT\Identity.JWT.csproj"/>
+        <ProjectReference Include="..\Identity.JWT\Identity.JWT.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Identity.API/Startup.cs
+++ b/Identity.API/Startup.cs
@@ -16,9 +16,15 @@ namespace Identity.API
         private IConfiguration Configuration { get; }
 
         public void ConfigureServices(IServiceCollection services) {
+            // application
             services.AddApplicationDependenciesInjection(Configuration);
             services.AddControllers();
             
+            // health check
+            services.AddHealthChecks()
+                .AddMongoDb(Configuration.GetConnectionString("dabit-user-mongo-db"));
+            
+            // cors
             services.AddCors(options =>
             {
                 options.AddPolicy(
@@ -45,7 +51,11 @@ namespace Identity.API
             app.UseRouting();
             app.UseCors("CorsPolicy");
             app.UseAuthorization();
-            app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+                endpoints.MapHealthChecks("/health");
+            });
         }
     }
 }


### PR DESCRIPTION
Adding health checks for:

| Name | Path | Checks  |
| --- | --- | --- |
| `Habit.API` | GET /health | mongodb |
| `Identity.API` | GET /health | mongodb |
| `Habit.Worker` | /tmp/healthy | mongodb, event store's subscription |

Unfortunately I couldn't find a satisfying solution to monitor the event-store connection's health. As mentioned in https://github.com/Xabaril/AspNetCore.Diagnostics.HealthChecks/issues/572, the package does not support gRPC yet. As for the subscription in `Habit.Worker`, an actual connection is made so I could retrieve the state from this.